### PR TITLE
dnspython module fixes in passive_recon.py

### DIFF
--- a/utils/passive_recon.py
+++ b/utils/passive_recon.py
@@ -31,9 +31,9 @@ async def dns_info(domain: str) -> str:
         if "www." in domain:
             domain = domain.replace("www.", "")
     try:
-        mail_exchange = dns.resolver.resolve(domain, "MX")
-        soa = dns.resolver.resolve(domain, "SOA")
-        cname = dns.resolver.resolve(domain, "CNAME")
+        mail_exchange = dns.resolver.Resolver(domain, "MX")
+        soa = dns.resolver.Resolver(domain, "SOA")
+        cname = dns.resolver.Resolver(domain, "CNAME")
         for mail_info in mail_exchange:
             mx.append(mail_info.to_text())
         for state_of_authority in soa:


### PR DESCRIPTION
previous output:

```
[+] - Waybackurls:  Saved to /output/waybackurls.txt
[+] - Subdomains:  Saved to /output/subdomains.txt
[+] - Domains:  Saved to /output/domains.txt
Traceback (most recent call last):
  File "/root/tools/Gsec/gsec.py", line 189, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/root/tools/Gsec/gsec.py", line 124, in main
    await asyncio.gather(
  File "/root/tools/Gsec/utils/passive_recon.py", line 35, in dns_info
    soa = dns.resolver.resolve(domain, "SOA")
          ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'dns.resolver' has no attribute 'resolve'. Did you mean: 'Resolver'?
```

after fixes:

```
[+] - Waybackurls:  Saved to /output/waybackurls.txt
[+] - Subdomains:  Saved to /output/subdomains.txt
[+] - Domains:  Saved to /output/domains.txt
```

Thanks.