### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ mmh3
 httpx
 scapy
 fake_useragent
+mechanize


### PR DESCRIPTION
mechanize requirement to fix this error:

```bash
➜  Gsec git:(main) python3 gsec.py
Traceback (most recent call last):
  File "/root/tools/Gsec/gsec.py", line 7, in <module>
    from vuln_db import hostheader_injection, nuclei_vulns, corsmisconfig, crossdomain, head_vuln, cache_poisoning, webservers_vulns, nmap_vuln, xss, broken_links
  File "/root/tools/Gsec/vuln_db/xss.py", line 6, in <module>
    import mechanize
ModuleNotFoundError: No module named 'mechanize'
```