### PR TITLE
NoResolverConfiguration error fixed

### DIFF
--- a/utils/passive_recon.py
+++ b/utils/passive_recon.py
@@ -22,6 +22,7 @@ async def whois_scan(domain: str) -> str:
 
 async def dns_info(domain: str) -> str:
     mx = []
+    resolver = dns.resolver.Resolver()
     if "https://" in domain:
         domain = domain.replace("https://", "")
         if "www." in domain:
@@ -31,19 +32,19 @@ async def dns_info(domain: str) -> str:
         if "www." in domain:
             domain = domain.replace("www.", "")
     try:
-        mail_exchange = dns.resolver.Resolver(domain, "MX")
-        soa = dns.resolver.Resolver(domain, "SOA")
-        cname = dns.resolver.Resolver(domain, "CNAME")
+        mail_exchange = resolver.resolve(domain, "MX")
+        soa = resolver.resolve(domain, "SOA")
+        cname = resolver.resolve(domain, "CNAME")
         for mail_info in mail_exchange:
             mx.append(mail_info.to_text())
         for state_of_authority in soa:
-            print(f"{Fore.MAGENTA}[+] {Fore.CYAN}-{Fore.WHITE} SOA: {Fore.GREEN}{state_of_authority.to_text()}")
+            print(f"[+] - SOA: {state_of_authority.to_text()}")
         for cnames in cname:
-            print(f"{Fore.MAGENTA}[+] {Fore.CYAN}-{Fore.WHITE} CNAME: {Fore.GREEN}{cnames.to_text()}")
-        print(f"{Fore.MAGENTA}[+] {Fore.CYAN}-{Fore.WHITE} MX: {Fore.GREEN}{', '.join(map(str,mx))}")
+            print(f"[+] - CNAME: {cnames.to_text()}")
+        print(f"[+] - MX: {', '.join(mx)}")
     except dns.resolver.NoAnswer:
         pass
-
+        
 async def shodan_search(domain: str) -> str:
     with open(f"core/.shodan", "r") as f:
         key = [x.strip() for x in f.readlines()]


### PR DESCRIPTION
while doing passive recon i encountered the following error which is fixed now:

```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/dns/resolver.py", line 992, in read_resolv_conf
    cm: contextlib.AbstractContextManager = open(f)
                                            ^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'apple.com'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/tools/Gsec/gsec.py", line 189, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/root/tools/Gsec/gsec.py", line 124, in main
    await asyncio.gather(
  File "/root/tools/Gsec/utils/passive_recon.py", line 34, in dns_info
    mail_exchange = dns.resolver.Resolver(domain, "MX")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/dns/resolver.py", line 944, in __init__
    self.read_resolv_conf(filename)
  File "/usr/local/lib/python3.11/dist-packages/dns/resolver.py", line 995, in read_resolv_conf
    raise NoResolverConfiguration(f"cannot open {f}")
dns.resolver.NoResolverConfiguration: cannot open apple.com
```