### PR TITLE
Fix timeout handling in sub_output.py

### DIFF
--- a/modules/sub_output.py
+++ b/modules/sub_output.py
@@ -63,8 +63,8 @@ def subpro_scan(command: str) -> Optional[str]:
         return output
         
     except subprocess.TimeoutExpired:
-        logger.error(f"Command timed out: {command}")
-        raise
+        logger.error(f"Command timed out after 60 seconds: {command}")
+        return None
         
     except FileNotFoundError:
         logger.error(f"Command not found: {command}")


### PR DESCRIPTION
- Change subprocess timeout exception to return None instead of raising
- Allows Gsec to continue and complete scan even if nuclei times out
- Minimal change for maximum compatibility and stability