### PR TITLE
Fix excessive false positives in path traversal detection (#30)

### DIFF
--- a/tests/test_path_traversal_detection.py
+++ b/tests/test_path_traversal_detection.py
@@ -1,0 +1,116 @@
+"""Tests for path traversal success detection (utils/path_traversal.py).
+
+These cover the false-positive fix from issue #30: the detector used to
+report a hit whenever a response merely contained keywords like "password",
+"database" or the substring "location{" (present in most sites' CSS/JS), so
+ordinary pages and WAF error pages were flagged as path traversal findings.
+Detection now requires the actual structure of a leaked file.
+
+Run with:  pytest tests/test_path_traversal_detection.py
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from utils.path_traversal import PathTraversalScanner
+
+TRAVERSAL_PAYLOAD = "../../../etc/passwd"
+
+
+def _response(body):
+    """Build a stand-in for requests.Response.
+
+    detect_traversal_success only reads ``.text``, so a live HTTP request is
+    unnecessary to exercise the detection logic.
+    """
+    return SimpleNamespace(text=body)
+
+
+# ---------------------------------------------------------------------------
+# False positives: ordinary responses that must NOT be flagged
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "description, body",
+    [
+        (
+            "login page with a password field",
+            "<form><label>Password:</label><input name='password'></form>",
+        ),
+        (
+            "CSS/JS containing the substring 'location{'",
+            "<style>a{color:red}.nav .location{top:0}</style>"
+            "<script>window.location={href:'/'}</script>",
+        ),
+        (
+            "marketing copy mentioning database and server_name",
+            "<p>Our database scales with every server_name you configure.</p>",
+        ),
+        (
+            "docs page mentioning Apache directives",
+            "<p>Set <code>DocumentRoot</code> and <code>ServerName</code> "
+            "then add a <code>LoadModule</code> line.</p>",
+        ),
+        (
+            "generic WAF block page",
+            "<html><body><h1>Access Denied</h1>"
+            "<p>Request blocked for security reasons.</p></body></html>",
+        ),
+        (
+            "a single passwd-shaped line embedded in prose",
+            "<pre>Example entry: root:x:0:0:root:/root:/bin/bash</pre>",
+        ),
+    ],
+)
+def test_benign_responses_are_not_flagged(description, body):
+    """Ordinary pages and WAF blocks are not reported as traversal hits."""
+    scanner = PathTraversalScanner()
+    flagged = scanner.detect_traversal_success(_response(body), TRAVERSAL_PAYLOAD)
+    assert flagged is False, description
+
+
+# ---------------------------------------------------------------------------
+# True positives: real file disclosures that MUST be flagged
+# ---------------------------------------------------------------------------
+
+def test_real_etc_passwd_is_flagged():
+    """A genuine /etc/passwd dump is still detected."""
+    scanner = PathTraversalScanner()
+    body = (
+        "root:x:0:0:root:/root:/bin/bash\n"
+        "daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin\n"
+        "bin:x:2:2:bin:/bin:/usr/sbin/nologin\n"
+        "www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin\n"
+    )
+    assert scanner.detect_traversal_success(_response(body), TRAVERSAL_PAYLOAD) is True
+
+
+def test_passwd_needs_more_than_one_line():
+    """A lone passwd-format line is not enough; a real file has many."""
+    scanner = PathTraversalScanner()
+    one_line = "root:x:0:0:root:/root:/bin/bash\n"
+    assert scanner.detect_traversal_success(_response(one_line), TRAVERSAL_PAYLOAD) is False
+
+
+def test_real_boot_ini_is_flagged():
+    """A genuine Windows boot.ini dump is still detected."""
+    scanner = PathTraversalScanner()
+    body = (
+        "[boot loader]\n"
+        "timeout=30\n"
+        "default=multi(0)disk(0)rdisk(0)partition(1)\\WINDOWS\n"
+        "[operating systems]\n"
+        "multi(0)disk(0)rdisk(0)partition(1)\\WINDOWS=\"Windows\"\n"
+    )
+    assert scanner.detect_traversal_success(_response(body), "..\\..\\..\\boot.ini") is True
+
+
+def test_real_access_log_is_flagged():
+    """A genuine access-log dump is still detected."""
+    scanner = PathTraversalScanner()
+    body = '127.0.0.1 - - [10/Oct/2024:13:55:36 +0000] "GET /index.html HTTP/1.1" 200 2326\n'
+    assert (
+        scanner.detect_traversal_success(_response(body), "../../var/log/nginx/access.log")
+        is True
+    )

--- a/utils/path_traversal.py
+++ b/utils/path_traversal.py
@@ -82,44 +82,37 @@ class PathTraversalScanner:
             "..././..././..././etc/passwd",
             "....\\....\\....\\windows\\win.ini",
         ]
-        
-        # Detection patterns for successful traversal
+
+        # Detection patterns for successful traversal.
+        #
+        # These match the *structure* of a leaked file, not just a keyword
+        # that happens to appear in normal page content. The previous list
+        # flagged any response containing words like "password", "database",
+        # "server_name" or the substring "location{" (present in almost every
+        # site's CSS/JS), so ordinary pages and WAF blocks were reported as
+        # path traversal findings (see issue #30). Every pattern is anchored
+        # or specific enough that a match is real evidence of file disclosure.
+        # /etc/passwd is handled separately in detect_traversal_success:
+        # it requires several lines that match the passwd account structure,
+        # since a genuine file always lists many accounts (root, daemon, ...)
+        # and requiring two real lines guards against a lone passwd-shaped
+        # line in, say, a documentation page.
         self.detection_patterns = [
-            # Linux /etc/passwd patterns
-            r"root:.*?:",
-            r"daemon:.*?:",
-            r"bin:.*?:",
-            r"sys:.*?:",
-            r"nobody:.*?:",
-            r"[a-zA-Z0-9_\-]+:[x*]:[\d]+:[\d]+:",
-            
-            # Windows system files
-            r"\[boot loader\]",
-            r"\[operating systems\]",
-            r"multi\(0\)disk\(0\)rdisk\(0\)",
-            r"# Copyright.*Microsoft Corp",
-            r"# This file contains the mappings",
-            
-            # Configuration files
-            r"DocumentRoot",
-            r"ServerName",
-            r"Listen.*:80",
-            r"LoadModule",
-            r"<VirtualHost",
-            r"server_name",
-            r"location.*{",
-            
-            # Database configs
-            r"password.*[:=]",
-            r"database.*[:=]",
-            r"DB_PASSWORD",
-            r"DB_HOST",
-            
-            # Log file patterns
-            r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}.*GET.*HTTP/",
-            r"\[\w{3}\s+\w{3}\s+\d{1,2}.*\]",
+            # Windows boot.ini / win.ini section headers and ARC paths
+            r"^\s*\[boot loader\]\s*$",
+            r"^\s*\[operating systems\]\s*$",
+            r"^\s*\[fonts\]\s*$",
+            r"^\s*\[extensions\]\s*$",
+            r"multi\(0\)disk\(0\)rdisk\(0\)partition\(",
+
+            # Windows hosts file banner (its distinctive comment lines)
+            r"This file contains the mappings of IP addresses to host names",
+
+            # Access/error log line: client IP followed by a quoted HTTP
+            # request line, as written by Apache/nginx in the common format.
+            r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b.*\"(?:GET|POST|HEAD|PUT|DELETE) .+ HTTP/\d",
         ]
-        
+
     def is_valid_url(self, url: str) -> bool:
         """Validate URL format."""
         try:
@@ -215,31 +208,27 @@ class PathTraversalScanner:
         """
         try:
             content = response.text
-            
+
             # Check for detection patterns
             for pattern in self.detection_patterns:
                 if re.search(pattern, content, re.IGNORECASE | re.MULTILINE):
                     return True
-            
-            # Additional checks for specific payloads
+
+            # Additional check for /etc/passwd: require several lines that
+            # actually match the passwd account structure (name:passwd:uid:
+            # gid:gecos:home:shell). Counting lines with "6 or more colons"
+            # was too loose - JS, timestamps and MAC-address lists all clear
+            # that bar - so a genuine passwd file needs multiple real lines.
             if "etc/passwd" in payload.lower():
-                # Look for Unix passwd file structure
-                lines = content.split('\n')
-                passwd_lines = 0
-                for line in lines:
-                    if ':' in line and len(line.split(':')) >= 6:
-                        passwd_lines += 1
-                
-                if passwd_lines >= 3:  # Multiple passwd-like lines
+                passwd_line = re.compile(
+                    r"^[a-zA-Z0-9_][a-zA-Z0-9_.\-]*:[^:\n]*:\d+:\d+:[^:\n]*:[^:\n]*:[^:\n]*$",
+                    re.MULTILINE,
+                )
+                if len(passwd_line.findall(content)) >= 2:
                     return True
-            
-            elif "win.ini" in payload.lower() or "boot.ini" in payload.lower():
-                # Look for Windows system file indicators
-                if any(indicator in content.lower() for indicator in ['[boot loader]', '[fonts]', '[extensions]']):
-                    return True
-            
+
             return False
-            
+
         except Exception as e:
             logger.error(f"Error in traversal detection: {str(e)}")
             return False


### PR DESCRIPTION
Fixes #30.

The detector reported a path traversal hit whenever the response just contained a keyword. The patterns included things like `password.*[:=]`, `database.*[:=]`, `server_name`, `DocumentRoot`, and even `location.*{` which shows up in almost every site's CSS/JS. So scanning a normal site (the issue uses shopify.com) flagged its ordinary pages and WAF blocks as findings.

I changed it to match the structure of an actually-leaked file instead of a keyword:

- `/etc/passwd`: needs at least two lines that match the real account structure `name:passwd:uid:gid:gecos:home:shell`, anchored per line. The old code counted lines with "6 or more colons", which JS, timestamps and MAC-address lists all pass.
- Windows `boot.ini`/`win.ini`: anchored section headers and ARC paths.
- hosts file and access/error logs: their distinctive lines.

I dropped the generic Apache/database config keywords. You can't really confirm a config-file leak from a word that also appears in normal page text, and those were the biggest false-positive source. Reliable config detection would need file-specific markers, which I think fits better as its own change.

Added `tests/test_path_traversal_detection.py` (10 tests) covering both directions: login pages, CSS with `location{`, marketing copy and Apache docs are no longer flagged, while real `/etc/passwd`, `boot.ini` and access-log responses still are. Run with `pytest tests/test_path_traversal_detection.py`.